### PR TITLE
src/systemd-status-mail: use bash, not sh, to avoid bashism warnings

### DIFF
--- a/src/systemd-status-mail
+++ b/src/systemd-status-mail
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$#" -ne 2 ]; then
     echo "Usage: $0 <mail address> <systemd unit>" >&2


### PR DESCRIPTION
OBS spits out a message that there are potential bashism in the script `src/systemd-status-mail`.

```bash
$ checkbashisms src/systemd-status-mail
possible bashism in src/systemd-status-mail line 20 ($HOST(TYPE|NAME)):
HOSTNAME=${HOSTNAME:-$(hostname)}
possible bashism in src/systemd-status-mail line 48 ($HOST(TYPE|NAME)):
        mailx $MAILX_OPTIONS -Ssendwait -s "$2 ($HOSTNAME)" -r "systemd <root@$HOSTNAME>" "$RELAY" "$1" <<EOF
$
```

Easy solution: Use `/bin/bash`, not `/bin/sh`.

Not sure if this is fine for you, so feel free to close this PR and I'll have a closer look, to see if I can get it working with pure sh...