### PR TITLE
Fix reboottrigger for SLES12

### DIFF
--- a/src/os-update.in
+++ b/src/os-update.in
@@ -68,7 +68,7 @@ check_and_reboot() {
         for rpm in $(rpm -q kernel-${flavor}) ; do
             installed=${rpm#kernel-${flavor}-}
             if [[ ${installed} > ${version}.1.$(uname -m) ]] ; then
-                reboottrigger = "yes"
+                reboottrigger="yes"
             fi
         done
     fi


### PR DESCRIPTION
Remove blank around equalsign, when assigning the value "yes" to the variable reboottrigger