### PR TITLE
Add LOG_TAG configuration option

### DIFF
--- a/src/os-update.8.md
+++ b/src/os-update.8.md
@@ -49,6 +49,9 @@ IGNORE_SERVICES_FROM_RESTART="dbus"
 SERVICES_TRIGGERING_REBOOT="dbus"
 : Specifies a list of services which trigger a reboot
 
+LOG_TAG="root"
+: Specifies a custom log identifier
+
 # CONFIGURATION FILES
 
 /usr/etc/os-update.conf

--- a/src/os-update.in
+++ b/src/os-update.in
@@ -32,13 +32,21 @@ ZYPPER_NONINTERACTIVE="-y --auto-agree-with-product-licenses"
 log_error()
 {
     echo "$@" >&2
-    logger --priority user.err "$@"
+    local LOG_ARGS="--priority user.err"
+    if [ -n "$LOG_TAG" ]; then
+        LOG_ARGS="$LOG_ARGS -t $LOG_TAG"
+    fi
+    logger ${LOG_ARGS} "$@"
 }
 
 log_info()
 {
     echo "$@"
-    logger "$@"
+    local LOG_ARGS=""
+    if [ -n "$LOG_TAG" ]; then
+        LOG_ARGS="$LOG_ARGS -t $LOG_TAG"
+    fi
+    logger ${LOG_ARGS} "$@"
 }
 
 usage() {


### PR DESCRIPTION
Hi,

I had the need to set a custom logging tag to make it easier for filtering results via syslog. Maybe this is useful for others as well. I didn't set a default in the os-update configuration to stay in line with logger's default, which is the name of user executing it (probably always root, in case of os-update).

Cheers
Georg